### PR TITLE
Fix SSH ownership and permission issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ Provided all the steps are completed properly, you will be prompted to enter the
 ![SSH Clone URL](./assets/clone_github.png)
 
 Once the repo is cloned, you can begin using your repo as normal through the Jupyter file manager interface.
+
+## Troubleshooting
+
+If you encounter issues where `git` operations take a long time only to ultimately fail, try running the setup script again.

--- a/setup.sh
+++ b/setup.sh
@@ -96,11 +96,30 @@ Host github.com
   IdentitiesOnly yes
 EOF
 
-chmod 600 "$KEYDIR/config"
-
 # Host key for GitHub:443
 ssh-keyscan -p 443 ssh.github.com >> "$KEYDIR/known_hosts"
+
+# -----------------------------
+# Fix SSH permissions and ownership
+# -----------------------------
+echo "Setting correct SSH permissions and ownership..."
+
+if [[ $EUID -eq 0 ]]; then
+  # Running as root
+  chown -R root:root "$KEYDIR"
+else
+  # Running as regular user
+  chown -R "$USER:$(id -gn)" "$KEYDIR"
+fi
+
+# Permissions are sometimes reset by the instance. Reapply them.
+chmod 700 "$KEYDIR"
+chmod 600 "$KEYDIR/config"
+chmod 600 "$KEYFILE"
+chmod 644 "$KEYFILE.pub"
 chmod 600 "$KEYDIR/known_hosts" 2>/dev/null || true
+
+echo "SSH permissions configured."
 
 # -----------------------------
 # Link ~/.ssh if not present


### PR DESCRIPTION
Both Alex and I had the issue of not being able to use `git` for ssh, as the files in `/home/y2a/ssh` were owned by UID 1000 instead of root.
`setup.sh` is now updated to set ownership based on the current user, such that rerunning the script fixes this issue.  

*(let's pretend I used the right git account to commit lol)*